### PR TITLE
#24 마신 술 모아보기

### DIFF
--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/measure_result/MeasureResultScreen.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/measure_result/MeasureResultScreen.kt
@@ -231,44 +231,52 @@ private fun MeasureResultDrinkAlcoholCupLayer(
             .clip(RoundedCornerShape(8.dp))
             .background(color = Grey050),
     ) {
-        MeasureResultDrinkAlcoholCupCountItem(
-            modifier = Modifier.padding(vertical = 16.dp),
-            alcoholType = AlcoholType.SOJU,
-            drinkCount = drinkCountOfSoju,
-        )
+        if (drinkCountOfSoju > 0) {
+            MeasureResultDrinkAlcoholCupCountItem(
+                modifier = Modifier.padding(vertical = 16.dp),
+                alcoholType = AlcoholType.SOJU,
+                drinkCount = drinkCountOfSoju,
+            )
 
-        Divider(
-            modifier = Modifier.padding(horizontal = 16.dp),
-            color = Grey200
-        )
+            Divider(
+                modifier = Modifier.padding(horizontal = 16.dp),
+                color = Grey200
+            )
+        }
 
-        MeasureResultDrinkAlcoholCupCountItem(
-            modifier = Modifier.padding(vertical = 16.dp),
-            alcoholType = AlcoholType.BEER,
-            drinkCount = drinkCountOfBeer,
-        )
+        if (drinkCountOfBeer > 0) {
+            MeasureResultDrinkAlcoholCupCountItem(
+                modifier = Modifier.padding(vertical = 16.dp),
+                alcoholType = AlcoholType.BEER,
+                drinkCount = drinkCountOfBeer,
+            )
 
-        Divider(
-            modifier = Modifier.padding(horizontal = 16.dp),
-            color = Grey200
-        )
+            Divider(
+                modifier = Modifier.padding(horizontal = 16.dp),
+                color = Grey200
+            )
+        }
 
-        MeasureResultDrinkAlcoholCupCountItem(
-            modifier = Modifier.padding(vertical = 16.dp),
-            alcoholType = AlcoholType.KAOLIANGJU,
-            drinkCount = drinkCountOfKaoliangju,
-        )
+        if (drinkCountOfKaoliangju > 0) {
+            MeasureResultDrinkAlcoholCupCountItem(
+                modifier = Modifier.padding(vertical = 16.dp),
+                alcoholType = AlcoholType.KAOLIANGJU,
+                drinkCount = drinkCountOfKaoliangju,
+            )
 
-        Divider(
-            modifier = Modifier.padding(horizontal = 16.dp),
-            color = Grey200
-        )
+            Divider(
+                modifier = Modifier.padding(horizontal = 16.dp),
+                color = Grey200
+            )
+        }
 
-        MeasureResultDrinkAlcoholCupCountItem(
-            modifier = Modifier.padding(vertical = 16.dp),
-            alcoholType = AlcoholType.WINE,
-            drinkCount = drinkCountOfWine,
-        )
+        if (drinkCountOfWine > 0) {
+            MeasureResultDrinkAlcoholCupCountItem(
+                modifier = Modifier.padding(vertical = 16.dp),
+                alcoholType = AlcoholType.WINE,
+                drinkCount = drinkCountOfWine,
+            )
+        }
     }
 }
 
@@ -337,8 +345,8 @@ private fun MeasureResultScreenPreview() {
             totalDrinkKcal = 132,
             totalDrinkAlcohol = 16.9f,
             totalDrinkTime = "3시간 20분",
-            drinkCountOfSoju = 3,
-            drinkCountOfBeer = 4,
+            drinkCountOfSoju = 14,
+            drinkCountOfBeer = 0,
             drinkCountOfKaoliangju = 3,
             drinkCountOfWine = 3,
         )

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/measure_result/MeasureResultScreen.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/measure_result/MeasureResultScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -27,6 +28,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.mashup.alcoholfree.presentation.R
@@ -35,6 +37,7 @@ import com.mashup.alcoholfree.presentation.measure_result.model.MeasureResultSta
 import com.mashup.alcoholfree.presentation.ui.theme.Grey050
 import com.mashup.alcoholfree.presentation.ui.theme.Grey200
 import com.mashup.alcoholfree.presentation.ui.theme.Grey300
+import com.mashup.alcoholfree.presentation.ui.theme.Grey700
 import com.mashup.alcoholfree.presentation.ui.theme.Grey800
 import com.mashup.alcoholfree.presentation.ui.theme.Grey900
 import com.mashup.alcoholfree.presentation.ui.theme.H1
@@ -298,11 +301,23 @@ private fun MeasureResultDrinkAlcoholCupCountItem(
 
         Spacer(modifier = Modifier.height(8.dp))
 
-        Row {
-            for (i in 0 until drinkCount) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            val maxCountToDisplay = 4
+
+            for (i in 0 until drinkCount.coerceAtMost(maxCountToDisplay)) {
                 Image(
                     painter = painterResource(id = alcoholType.iconResId),
                     contentDescription = null
+                )
+            }
+
+            if (drinkCount > maxCountToDisplay) {
+                Text(
+                    modifier = Modifier.widthIn(min = 52.dp),
+                    text = "+${drinkCount - maxCountToDisplay}",
+                    style = H4,
+                    color = Grey700,
+                    textAlign = TextAlign.Center
                 )
             }
         }

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/measure_result/MeasureResultScreen.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/measure_result/MeasureResultScreen.kt
@@ -13,7 +13,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -294,7 +294,11 @@ private fun MeasureResultDrinkAlcoholCupCountItem(
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(
-            text = stringResource(id = R.string.drink_type_and_count, alcoholType.title, drinkCount),
+            text = stringResource(
+                id = R.string.drink_type_and_count,
+                alcoholType.title,
+                drinkCount
+            ),
             style = H5,
             color = White,
         )
@@ -325,7 +329,7 @@ private fun MeasureResultDrinkAlcoholCups(
 
         if (drinkCount > maxCountToDisplay) {
             Text(
-                modifier = Modifier.widthIn(min = 52.dp),
+                modifier = Modifier.width(52.dp),
                 text = "+${drinkCount - maxCountToDisplay}",
                 style = H4,
                 color = Grey700,
@@ -371,7 +375,7 @@ private fun MeasureResultScreenPreview() {
             totalDrinkKcal = 132,
             totalDrinkAlcohol = 16.9f,
             totalDrinkTime = "3시간 20분",
-            drinkCountOfSoju = 14,
+            drinkCountOfSoju = 999,
             drinkCountOfBeer = 0,
             drinkCountOfKaoliangju = 3,
             drinkCountOfWine = 3,

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/measure_result/MeasureResultScreen.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/measure_result/MeasureResultScreen.kt
@@ -234,7 +234,8 @@ private fun MeasureResultDrinkAlcoholCupLayer(
             .clip(RoundedCornerShape(8.dp))
             .background(color = Grey050),
     ) {
-        if (drinkCountOfSoju > 0) {
+        val zero = 0
+        if (drinkCountOfSoju > zero) {
             MeasureResultDrinkAlcoholCupCountItem(
                 modifier = Modifier.padding(vertical = 16.dp),
                 alcoholType = AlcoholType.SOJU,
@@ -247,7 +248,7 @@ private fun MeasureResultDrinkAlcoholCupLayer(
             )
         }
 
-        if (drinkCountOfBeer > 0) {
+        if (drinkCountOfBeer > zero) {
             MeasureResultDrinkAlcoholCupCountItem(
                 modifier = Modifier.padding(vertical = 16.dp),
                 alcoholType = AlcoholType.BEER,
@@ -260,7 +261,7 @@ private fun MeasureResultDrinkAlcoholCupLayer(
             )
         }
 
-        if (drinkCountOfKaoliangju > 0) {
+        if (drinkCountOfKaoliangju > zero) {
             MeasureResultDrinkAlcoholCupCountItem(
                 modifier = Modifier.padding(vertical = 16.dp),
                 alcoholType = AlcoholType.KAOLIANGJU,
@@ -273,7 +274,7 @@ private fun MeasureResultDrinkAlcoholCupLayer(
             )
         }
 
-        if (drinkCountOfWine > 0) {
+        if (drinkCountOfWine > zero) {
             MeasureResultDrinkAlcoholCupCountItem(
                 modifier = Modifier.padding(vertical = 16.dp),
                 alcoholType = AlcoholType.WINE,

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/measure_result/MeasureResultScreen.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/measure_result/MeasureResultScreen.kt
@@ -301,25 +301,36 @@ private fun MeasureResultDrinkAlcoholCupCountItem(
 
         Spacer(modifier = Modifier.height(8.dp))
 
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            val maxCountToDisplay = 4
+        MeasureResultDrinkAlcoholCups(
+            alcoholIconResId = alcoholType.iconResId,
+            drinkCount = drinkCount,
+        )
+    }
+}
 
-            for (i in 0 until drinkCount.coerceAtMost(maxCountToDisplay)) {
-                Image(
-                    painter = painterResource(id = alcoholType.iconResId),
-                    contentDescription = null
-                )
-            }
+@Composable
+private fun MeasureResultDrinkAlcoholCups(
+    alcoholIconResId: Int,
+    drinkCount: Int,
+) {
+    val maxCountToDisplay = 4
 
-            if (drinkCount > maxCountToDisplay) {
-                Text(
-                    modifier = Modifier.widthIn(min = 52.dp),
-                    text = "+${drinkCount - maxCountToDisplay}",
-                    style = H4,
-                    color = Grey700,
-                    textAlign = TextAlign.Center
-                )
-            }
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        for (i in 0 until drinkCount.coerceAtMost(maxCountToDisplay)) {
+            Image(
+                painter = painterResource(id = alcoholIconResId),
+                contentDescription = null
+            )
+        }
+
+        if (drinkCount > maxCountToDisplay) {
+            Text(
+                modifier = Modifier.widthIn(min = 52.dp),
+                text = "+${drinkCount - maxCountToDisplay}",
+                style = H4,
+                color = Grey700,
+                textAlign = TextAlign.Center
+            )
         }
     }
 }


### PR DESCRIPTION
## 주요사항
- 마시지 않은 경우 목록에 노출하지 않기
- 5잔 이상 마신 경우 숫자로 옆에 숫자로 보여주기
<img width="262" alt="스크린샷 2023-06-10 오후 7 26 46" src="https://github.com/mash-up-kr/SulSul-Android/assets/78132126/0799b280-135a-44be-89e1-9350cee56373">

## 고민
최대 보여줄 수 있는 잔 수를 나타내는 변수가 있는데 컴포저블 안에 둬도 되려나요? 저 컴포저블에서만 쓰는거라 전역으로 빼고 싶지는 않아서 안에 두긴 했는데 마음에 걸리네요