### PR TITLE
#19 홈 레이아웃 구조 만들기

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -32,5 +32,6 @@
         </activity>
         <activity android:name=".ui.login.LoginActivity" />
         <activity android:name=".measure_result.MeasureResultActivity" />
+        <activity android:name=".ui.home.HomeActivity" />
     </application>
 </manifest>

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/debug_bridge/DebugBridgeActivity.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/debug_bridge/DebugBridgeActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import com.mashup.alcoholfree.presentation.measure_result.MeasureResultActivity
+import com.mashup.alcoholfree.presentation.ui.home.HomeActivity
 import com.mashup.alcoholfree.presentation.ui.login.LoginActivity
 
 class DebugBridgeActivity : ComponentActivity() {
@@ -15,6 +16,7 @@ class DebugBridgeActivity : ComponentActivity() {
                 items = listOf(
                     LoginActivity::class.java,
                     MeasureResultActivity::class.java,
+                    HomeActivity::class.java,
                 )
             )
         }

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/HomeActivity.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/HomeActivity.kt
@@ -3,13 +3,20 @@ package com.mashup.alcoholfree.presentation.ui.home
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import com.mashup.alcoholfree.presentation.ui.home.model.AlcoholLevel
+import com.mashup.alcoholfree.presentation.ui.home.model.HomeState
 
 class HomeActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         setContent {
-            HomeScreen()
+            HomeScreen(
+                HomeState(
+                    userName = "우진",
+                    alcoholLevel = AlcoholLevel.LEVEL3
+                )
+            )
         }
     }
 }

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/HomeActivity.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/HomeActivity.kt
@@ -1,0 +1,15 @@
+package com.mashup.alcoholfree.presentation.ui.home
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+
+class HomeActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            HomeScreen()
+        }
+    }
+}

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/HomeScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.mashup.alcoholfree.presentation.R
@@ -29,7 +30,7 @@ fun HomeScreen(
     ) {
         Text(
             modifier = Modifier.padding(top = 40.dp),
-            text = "${state.userName}님은",
+            text = stringResource(id = R.string.home_title, state.userName),
             style = H2,
             color = White,
         )
@@ -39,7 +40,7 @@ fun HomeScreen(
         )
         Text(
             modifier = Modifier.padding(top = 24.dp),
-            text = "나의 술 약속\uD83C\uDF7E",
+            text = stringResource(id = R.string.home_alcohol_appointment_text),
             style = H3,
             color = White,
         )
@@ -55,7 +56,7 @@ fun HomeScreen(
                 .align(Alignment.CenterHorizontally)
                 .padding(top = 35.dp, bottom = 40.dp),
             imageResId = R.drawable.ic_plus,
-            content = "술 마시러 가기",
+            content = stringResource(id = R.string.home_button_text),
             buttonColor = SulSulButtonColor.GREY300,
             buttonSize = SulSulButtonSize.LARGE,
         )

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/HomeScreen.kt
@@ -15,27 +15,27 @@ import com.mashup.alcoholfree.presentation.ui.component.model.SulSulButtonColor
 import com.mashup.alcoholfree.presentation.ui.component.model.SulSulButtonSize
 import com.mashup.alcoholfree.presentation.ui.home.component.AlcoholLevelCard
 import com.mashup.alcoholfree.presentation.ui.home.model.AlcoholLevel
+import com.mashup.alcoholfree.presentation.ui.home.model.HomeState
 import com.mashup.alcoholfree.presentation.ui.theme.H2
 import com.mashup.alcoholfree.presentation.ui.theme.H3
 import com.mashup.alcoholfree.presentation.ui.theme.White
 
 @Composable
-fun HomeScreen() {
-    val name = "우진"
-    val alcoholLevel = AlcoholLevel.LEVEL3
-
+fun HomeScreen(
+    state: HomeState,
+) {
     Column(
         modifier = Modifier.padding(horizontal = 16.dp),
     ) {
         Text(
             modifier = Modifier.padding(top = 40.dp),
-            text = "${name}님은",
+            text = "${state.userName}님은",
             style = H2,
             color = White,
         )
         AlcoholLevelCard(
             modifier = Modifier.padding(top = 8.dp),
-            alcoholLevel = alcoholLevel,
+            alcoholLevel = state.alcoholLevel,
         )
         Text(
             modifier = Modifier.padding(top = 24.dp),
@@ -65,5 +65,10 @@ fun HomeScreen() {
 @Preview
 @Composable
 fun HomeScreenPreview() {
-    HomeScreen()
+    HomeScreen(
+        HomeState(
+            userName = "우진",
+            alcoholLevel = AlcoholLevel.LEVEL3,
+        )
+    )
 }

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/HomeScreen.kt
@@ -1,0 +1,69 @@
+package com.mashup.alcoholfree.presentation.ui.home
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.mashup.alcoholfree.presentation.R
+import com.mashup.alcoholfree.presentation.ui.component.SulSulIconStartButton
+import com.mashup.alcoholfree.presentation.ui.component.model.SulSulButtonColor
+import com.mashup.alcoholfree.presentation.ui.component.model.SulSulButtonSize
+import com.mashup.alcoholfree.presentation.ui.home.component.AlcoholLevelCard
+import com.mashup.alcoholfree.presentation.ui.home.model.AlcoholLevel
+import com.mashup.alcoholfree.presentation.ui.theme.H2
+import com.mashup.alcoholfree.presentation.ui.theme.H3
+import com.mashup.alcoholfree.presentation.ui.theme.White
+
+@Composable
+fun HomeScreen() {
+    val name = "우진"
+    val alcoholLevel = AlcoholLevel.LEVEL3
+
+    Column(
+        modifier = Modifier.padding(horizontal = 16.dp),
+    ) {
+        Text(
+            modifier = Modifier.padding(top = 40.dp),
+            text = "${name}님은",
+            style = H2,
+            color = White,
+        )
+        AlcoholLevelCard(
+            modifier = Modifier.padding(top = 8.dp),
+            alcoholLevel = alcoholLevel,
+        )
+        Text(
+            modifier = Modifier.padding(top = 24.dp),
+            text = "나의 술 약속\uD83C\uDF7E",
+            style = H3,
+            color = White,
+        )
+        /* TODO: 술 약속 카드 컴포넌트가 들어와야함 */
+        Box(
+            modifier = Modifier.padding(top = 16.dp),
+        ) {
+
+        }
+
+        SulSulIconStartButton(
+            modifier = Modifier
+                .align(Alignment.CenterHorizontally)
+                .padding(top = 35.dp, bottom = 40.dp),
+            imageResId = R.drawable.ic_plus,
+            content = "술 마시러 가기",
+            buttonColor = SulSulButtonColor.GREY300,
+            buttonSize = SulSulButtonSize.LARGE,
+        )
+    }
+}
+
+@Preview
+@Composable
+fun HomeScreenPreview() {
+    HomeScreen()
+}

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/component/AlcoholLevelCard.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/component/AlcoholLevelCard.kt
@@ -29,7 +29,7 @@ fun AlcoholLevelCard(
     /* TODO: grainy background 적용해야함 */
     Box(
         modifier = modifier
-        .width(328.dp)
+        .fillMaxWidth()
         .height(111.dp),
     ) {
         Row(

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/model/HomeState.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/model/HomeState.kt
@@ -1,0 +1,6 @@
+package com.mashup.alcoholfree.presentation.ui.home.model
+
+data class HomeState(
+    val userName: String,
+    val alcoholLevel: AlcoholLevel,
+)

--- a/presentation/src/main/res/drawable/ic_plus.xml
+++ b/presentation/src/main/res/drawable/ic_plus.xml
@@ -6,13 +6,13 @@
   <path
       android:pathData="M12,4V20"
       android:strokeWidth="1.5"
-      android:fillColor="#00000000"
-      android:strokeColor="#000000"
+      android:fillColor="#FFFFFFFF"
+      android:strokeColor="#FFFFFF"
       android:strokeLineCap="round"/>
   <path
       android:pathData="M4,12L20,12"
       android:strokeWidth="1.5"
-      android:fillColor="#00000000"
-      android:strokeColor="#000000"
+      android:fillColor="#FFFFFFFF"
+      android:strokeColor="#FFFFFF"
       android:strokeLineCap="round"/>
 </vector>

--- a/presentation/src/main/res/drawable/ic_plus.xml
+++ b/presentation/src/main/res/drawable/ic_plus.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,4V20"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M4,12L20,12"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -13,4 +13,7 @@
     <string name="my_alcohol_stat_intro_label">내 술 능력치는 얼만큼?</string>
     <string name="my_alcohol_intro_label">주종별 내 주량 궁금하지 않으신가요?</string>
     <string name="measure_intro_label">지금 측정해보세요!</string>
+    <string name="home_title">%s님은</string>
+    <string name="home_alcohol_appointment_text">나의 술 약속🍾</string>
+    <string name="home_button_text">술 마시러 가기</string>
 </resources>


### PR DESCRIPTION
## 수정한 점
* 홈 레이아웃 구조 생성
* 칭호 카드의 넓이를 꽉 채우게 변경

## 추후 수정해야 할 점
* 전체적으로 배경을 빨리 입혀야될듯..ㅎ
* 술 약속 카드 컴포넌트가 들어와야함 (box의 modifier는 그대로 사용해도 됩니다~)

## 스크린 샷
![image](https://github.com/mash-up-kr/SulSul-Android/assets/22673963/1764a69c-f365-4ba2-9c59-0f1c45acb54c)
