### PR TITLE
#58 [홈] 술 약속 카드 클릭 시 측정 결과 화면으로 이동 

### DIFF
--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/HomeActivity.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/HomeActivity.kt
@@ -6,7 +6,9 @@ import androidx.activity.compose.setContent
 import com.mashup.alcoholfree.presentation.ui.home.model.AlcoholPromiseCardState
 import com.mashup.alcoholfree.presentation.ui.home.model.AlcoholTier
 import com.mashup.alcoholfree.presentation.ui.home.model.HomeState
+import com.mashup.alcoholfree.presentation.ui.measureresult.MeasureResultActivity
 import com.mashup.alcoholfree.presentation.utils.ImmutableList
+import com.mashup.alcoholfree.presentation.utils.moveToActivity
 
 class HomeActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -19,6 +21,7 @@ class HomeActivity : ComponentActivity() {
                     alcoholTier = AlcoholTier.LEVEL3,
                     cardList = ImmutableList(AlcoholPromiseCardState.sampleCardList()),
                 ),
+                onAlcoholCardClick = { moveToActivity(MeasureResultActivity::class.java) },
             )
         }
     }

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/HomeScreen.kt
@@ -38,6 +38,7 @@ import com.mashup.alcoholfree.presentation.utils.ImmutableList
 @Composable
 fun HomeScreen(
     state: HomeState,
+    onAlcoholCardClick: () -> Unit,
 ) {
     Box(
         modifier = Modifier
@@ -95,6 +96,7 @@ fun HomeScreen(
                     .padding(top = 16.dp)
                     .weight(1f),
                 cardList = state.cardList,
+                onAlcoholCardClick = onAlcoholCardClick,
             )
 
             SulSulIconStartButton(
@@ -119,5 +121,6 @@ fun HomeScreenPreview() {
             alcoholTier = AlcoholTier.LEVEL3,
             cardList = ImmutableList(AlcoholPromiseCardState.sampleCardList()),
         ),
+        onAlcoholCardClick = {},
     )
 }

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/component/AlcoholPromiseCard.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/component/AlcoholPromiseCard.kt
@@ -3,6 +3,7 @@ package com.mashup.alcoholfree.presentation.ui.home.component
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -42,10 +43,12 @@ private val cardShape = RoundedCornerShape(16.dp)
 fun AlcoholPromiseCard(
     modifier: Modifier = Modifier,
     state: AlcoholPromiseCardState,
+    onAlcoholCardClick: () -> Unit,
 ) {
     val alcoholType = AlcoholPromiseCardState.getAlcoholType(state.drinks.list.first())
     Column(
         modifier = modifier
+            .clickable { onAlcoholCardClick() }
             .clip(shape = cardShape)
             .border(width = 1.dp, color = Grey300, shape = cardShape)
             .paint(
@@ -142,6 +145,7 @@ private fun AlcoholPromiseCardPreview() {
                 drankDate = "2023.08.21",
                 subTitleText = "술 좀 치네",
             ),
+            onAlcoholCardClick = {},
         )
     }
 }

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/component/AlcoholPromiseCardPager.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/component/AlcoholPromiseCardPager.kt
@@ -18,6 +18,7 @@ import kotlin.math.absoluteValue
 fun AlcoholPromiseCardPager(
     modifier: Modifier = Modifier,
     cardList: ImmutableList<AlcoholPromiseCardState>,
+    onAlcoholCardClick: () -> Unit,
 ) {
     val pagerState = rememberPagerState()
     HorizontalPager(
@@ -49,6 +50,7 @@ fun AlcoholPromiseCardPager(
                 )
             },
             state = cardList.list[page],
+            onAlcoholCardClick = onAlcoholCardClick,
         )
     }
 }

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/utils/ActivityKtx.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/utils/ActivityKtx.kt
@@ -1,0 +1,10 @@
+package com.mashup.alcoholfree.presentation.utils
+
+import android.app.Activity
+import android.content.Intent
+
+fun Activity.moveToActivity(activity: Class<*>) {
+    startActivity(
+        Intent(this, activity),
+    )
+}


### PR DESCRIPTION
+ 술 약속 카드 클릭하면 측정결과 화면으로 이동하게 클릭리스너 구현했습니다~
+ 이동만 가능하게 했고 추후 인자가 추가 되어야 될것 같습니다.
+ startActivity가 많이 사용될거 같아서 익스텐션으로 빼놨구요. 이것도 나중에 bundle 같은 인자가 추가 되어야 할것 같긴 합니당
+ 저거 따로 빼놓은 익스텐션 코드 별로거나 더 좋은 방법이 있으면 말씀해주십시오..!  수정하겠습니당