### PR TITLE
#81 - [공통] status bar 색상

### DIFF
--- a/buildSrc/src/main/java/Version.kt
+++ b/buildSrc/src/main/java/Version.kt
@@ -60,6 +60,7 @@ object Dependencies {
         private const val VERSION = "0.30.1"
 
         const val ACCOMPANIST_WEBVIEW = "com.google.accompanist:accompanist-webview:$VERSION"
+        const val ACCOMPANIST_SYSTEM_UI_CONTROLLER = "com.google.accompanist:accompanist-systemuicontroller:$VERSION"
     }
 
     object Coil {

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
     implementation(Dependencies.Compose.COMPOSE_PREVIEW)
     implementation(Dependencies.Compose.COMPOSE_MATERIAL)
     implementation(Dependencies.Accompanist.ACCOMPANIST_WEBVIEW)
+    implementation(Dependencies.Accompanist.ACCOMPANIST_SYSTEM_UI_CONTROLLER)
 
     // dagger hilt
     implementation(Dependencies.Hilt.HILT_ANDROID)

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/HomeActivity.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/HomeActivity.kt
@@ -3,26 +3,31 @@ package com.mashup.alcoholfree.presentation.ui.home
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.core.view.WindowCompat
 import com.mashup.alcoholfree.presentation.ui.home.model.AlcoholPromiseCardState
 import com.mashup.alcoholfree.presentation.ui.home.model.AlcoholTier
 import com.mashup.alcoholfree.presentation.ui.home.model.HomeState
 import com.mashup.alcoholfree.presentation.ui.measureresult.MeasureResultActivity
+import com.mashup.alcoholfree.presentation.ui.theme.AlcoholFreeAndroidTheme
 import com.mashup.alcoholfree.presentation.utils.ImmutableList
 import com.mashup.alcoholfree.presentation.utils.moveToActivity
 
 class HomeActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
 
         setContent {
-            HomeScreen(
-                state = HomeState(
-                    userName = "우진",
-                    alcoholTier = AlcoholTier.LEVEL3,
-                    cardList = ImmutableList(AlcoholPromiseCardState.sampleCardList()),
-                ),
-                onAlcoholCardClick = { moveToActivity(MeasureResultActivity::class.java) },
-            )
+            AlcoholFreeAndroidTheme {
+                HomeScreen(
+                    state = HomeState(
+                        userName = "우진",
+                        alcoholTier = AlcoholTier.LEVEL3,
+                        cardList = ImmutableList(AlcoholPromiseCardState.sampleCardList()),
+                    ),
+                    onAlcoholCardClick = { moveToActivity(MeasureResultActivity::class.java) },
+                )
+            }
         }
     }
 }

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/HomeScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -71,7 +72,10 @@ fun HomeScreen(
             ),
         contentAlignment = Alignment.TopCenter,
     ) {
-        Column {
+        Column(
+            modifier = Modifier
+                .statusBarsPadding(),
+        ) {
             Text(
                 modifier = Modifier.padding(top = 40.dp, start = 16.dp),
                 text = stringResource(id = R.string.home_title, state.userName),

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/login/LoginActivity.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/login/LoginActivity.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.ui.Modifier
+import androidx.core.view.WindowCompat
 import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
 import com.kakao.sdk.common.util.Utility
@@ -24,6 +25,7 @@ class LoginActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         Log.d("Kakao KeyHash : ", getKakaoKeyHash())
+        WindowCompat.setDecorFitsSystemWindows(window, false)
 
         setContent {
             AlcoholFreeAndroidTheme {

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measureresult/MeasureResultActivity.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measureresult/MeasureResultActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
+import androidx.core.view.WindowCompat
 import com.mashup.alcoholfree.presentation.ui.measureresult.model.MeasureResultState
 import com.mashup.alcoholfree.presentation.ui.theme.AlcoholFreeAndroidTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -14,6 +15,8 @@ class MeasureResultActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+
         setContent {
             AlcoholFreeAndroidTheme {
                 MeasureResultScreen(

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measureresult/MeasureResultScreen.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measureresult/MeasureResultScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -124,7 +125,9 @@ fun MeasureResultScreen(
 @Composable
 private fun MeasureResultContent(state: MeasureResultState) {
     Column(
-        modifier = Modifier.verticalScroll(rememberScrollState()),
+        modifier = Modifier
+            .verticalScroll(rememberScrollState())
+            .statusBarsPadding(),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         MeasureResultHeader(

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/MeasuringActivity.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/MeasuringActivity.kt
@@ -8,33 +8,39 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.core.view.WindowCompat
 import com.mashup.alcoholfree.presentation.ui.measuring.model.MeasuringState
+import com.mashup.alcoholfree.presentation.ui.theme.AlcoholFreeAndroidTheme
 
 class MeasuringActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+
         setContent {
-            var alcoholId by remember { mutableStateOf(0) }
-            var state by remember {
-                mutableStateOf(
-                    MeasuringState(
-                        totalCount = 25,
-                        records = "와인 2잔 · 소주 2잔 · 맥주 3잔",
-                        level = "미쳤다",
-                        currentAlcoholId = alcoholId,
-                        alcoholTypes = listOf("소주", "맥주", "위스키", "와인", "고량주"),
+            AlcoholFreeAndroidTheme {
+                var alcoholId by remember { mutableStateOf(0) }
+                var state by remember {
+                    mutableStateOf(
+                        MeasuringState(
+                            totalCount = 25,
+                            records = "와인 2잔 · 소주 2잔 · 맥주 3잔",
+                            level = "미쳤다",
+                            currentAlcoholId = alcoholId,
+                            alcoholTypes = listOf("소주", "맥주", "위스키", "와인", "고량주"),
+                        )
                     )
+                }
+
+                LaunchedEffect(key1 = alcoholId) {
+                    state = state.copy(currentAlcoholId = alcoholId)
+                }
+
+                MeasuringScreen(
+                    state = state,
+                    onAlcoholSelectionChanged = { alcoholId = it },
                 )
             }
-
-            LaunchedEffect(key1 = alcoholId) {
-                state = state.copy(currentAlcoholId = alcoholId)
-            }
-
-            MeasuringScreen(
-                state = state,
-                onAlcoholSelectionChanged = { alcoholId = it },
-            )
         }
     }
 }

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/MeasuringScreen.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/MeasuringScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.material.ripple.rememberRipple
@@ -94,13 +95,16 @@ fun MeasuringScreen(
     ) {
         SulSulBackButton(
             modifier = Modifier
+                .statusBarsPadding()
                 .padding(top = 8.dp, start = 16.dp)
                 .align(Alignment.TopStart),
             onClick = onBackButtonClick,
         )
 
         Column(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxSize()
+                .statusBarsPadding(),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             MeasuringHeader(

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/theme/Theme.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/theme/Theme.kt
@@ -5,6 +5,9 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.Color
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
 private val DarkColorPalette = darkColors(
     primary = Purple200,
@@ -36,6 +39,11 @@ fun AlcoholFreeAndroidTheme(
         DarkColorPalette
     } else {
         LightColorPalette
+    }
+
+    val systemUiController = rememberSystemUiController()
+    SideEffect {
+        systemUiController.setSystemBarsColor(Color.Transparent)
     }
 
     MaterialTheme(


### PR DESCRIPTION
- close #81 
- 기본 테마에서 투명하게 걸어두었습니당

<img width="300" alt="스크린샷 2023-07-26 오후 11 50 31" src="https://github.com/mash-up-kr/SulSul-Android/assets/78132126/86ecf4c9-ec56-48b4-91e9-dc33d7b01b64">
<img width="300" alt="스크린샷 2023-07-26 오후 11 49 09" src="https://github.com/mash-up-kr/SulSul-Android/assets/78132126/63ddc294-fae3-4245-8a46-c9502cebc88c">
<img width="300" alt="스크린샷 2023-07-26 오후 11 49 37" src="https://github.com/mash-up-kr/SulSul-Android/assets/78132126/23d49ea1-51a9-4129-8793-46465493fa30">
<img width="300" alt="스크린샷 2023-07-26 오후 11 50 10" src="https://github.com/mash-up-kr/SulSul-Android/assets/78132126/b86056a0-59fd-4d15-b6c1-0fda7ee3b79b">
