### PR TITLE
#92 [주량 측정] 주량 측정 로직 추가

### DIFF
--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/MeasuringActivity.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/MeasuringActivity.kt
@@ -45,6 +45,7 @@ class MeasuringActivity : ComponentActivity() {
 
     private fun navigateToMeasureResult(reportId: String) {
         startActivity(MeasureResultActivity.newIntent(this, reportId))
+        finish()
     }
 
     companion object {

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/MeasuringActivity.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/MeasuringActivity.kt
@@ -8,6 +8,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.mashup.alcoholfree.presentation.ui.theme.AlcoholFreeAndroidTheme
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -19,13 +20,16 @@ class MeasuringActivity : ComponentActivity() {
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
         setContent {
-            val state = viewModel.state.collectAsStateWithLifecycle()
+            AlcoholFreeAndroidTheme {
+                val state = viewModel.state.collectAsStateWithLifecycle()
 
-            MeasuringScreen(
-                state = state.value,
-                onAlcoholSelectionChanged = { viewModel.updateCurrentAlcoholId(it) },
-                onBackButtonClick = { finish() },
-            )
+                MeasuringScreen(
+                    state = state.value,
+                    onAlcoholSelectionChanged = { viewModel.updateCurrentAlcoholId(it) },
+                    onBackButtonClick = { finish() },
+                    onAddBallSuccess = viewModel::addAlcoholItem
+                )
+            }
         }
     }
 

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/MeasuringActivity.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/MeasuringActivity.kt
@@ -8,7 +8,9 @@ import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.mashup.alcoholfree.presentation.ui.measureresult.MeasureResultActivity
 import com.mashup.alcoholfree.presentation.ui.theme.AlcoholFreeAndroidTheme
+import com.mashup.alcoholfree.presentation.utils.observeEvent
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -27,10 +29,22 @@ class MeasuringActivity : ComponentActivity() {
                     state = state.value,
                     onAlcoholSelectionChanged = { viewModel.updateCurrentAlcoholId(it) },
                     onBackButtonClick = { finish() },
-                    onAddBallSuccess = viewModel::addAlcoholItem
+                    onAddBallSuccess = viewModel::addAlcoholItem,
+                    onMeasureFinishClick = viewModel::createMeasureResultReport,
                 )
             }
         }
+        observeData()
+    }
+
+    private fun observeData() {
+        viewModel.createReportSuccessEvent.observeEvent(this) { reportId ->
+            navigateToMeasureResult(reportId)
+        }
+    }
+
+    private fun navigateToMeasureResult(reportId: String) {
+        startActivity(MeasureResultActivity.newIntent(this, reportId))
     }
 
     companion object {

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/MeasuringScreen.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/MeasuringScreen.kt
@@ -61,6 +61,7 @@ fun MeasuringScreen(
     onAlcoholSelectionChanged: (Int) -> Unit = {},
     onMeasureFinishClick: () -> Unit = {},
     onBackButtonClick: () -> Unit = {},
+    onAddBallSuccess: (String) -> Unit = {},
 ) {
     val gradientColorList = setGradientColor(state.currentAlcoholId)
     Box(
@@ -86,6 +87,7 @@ fun MeasuringScreen(
         state = SulSulWebViewState(
             state.alcoholTypes.list[state.currentAlcoholId],
         ),
+        onAddBallSuccess = onAddBallSuccess,
     )
 
     Box(
@@ -206,12 +208,13 @@ private fun MeasuringHeader(
 private fun MeasuringBubblesContainer(
     modifier: Modifier = Modifier,
     state: SulSulWebViewState,
+    onAddBallSuccess: (String) -> Unit,
 ) {
     SulSulWebView(
         modifier = modifier,
         url = WEB_FALLING_URL,
         state = state,
-        bridge = MeasuringWebViewBridge,
+        bridge = MeasuringWebViewBridge(onSuccess = onAddBallSuccess),
         isTransparent = true,
     )
 }

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/MeasuringViewModel.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/MeasuringViewModel.kt
@@ -1,5 +1,7 @@
 package com.mashup.alcoholfree.presentation.ui.measuring
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.mashup.alcoholfree.domain.usecase.CreateMeasureResultReportUseCase
@@ -7,6 +9,7 @@ import com.mashup.alcoholfree.presentation.ui.home.model.DrinkUiModel
 import com.mashup.alcoholfree.presentation.ui.home.model.MeasureResultReportParamUiModel
 import com.mashup.alcoholfree.presentation.ui.home.model.toDomainModel
 import com.mashup.alcoholfree.presentation.ui.measuring.model.MeasuringState
+import com.mashup.alcoholfree.presentation.utils.Event
 import com.mashup.alcoholfree.presentation.utils.ImmutableList
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -24,6 +27,10 @@ class MeasuringViewModel @Inject constructor(
     private val _state = MutableStateFlow(initState())
     val state: StateFlow<MeasuringState>
         get() = _state
+
+    private val _createReportSuccessEvent = MutableLiveData<Event<String>>()
+    val createReportSuccessEvent: LiveData<Event<String>>
+        get() = _createReportSuccessEvent
 
     private val drinkingStartTime = getDateTimeNow()
     private val drinkingMap = mutableMapOf<String, Int>()
@@ -46,7 +53,7 @@ class MeasuringViewModel @Inject constructor(
 
     fun createMeasureResultReport() {
         viewModelScope.launch {
-            createMeasureResultReportUseCase(
+            val result = createMeasureResultReportUseCase(
                 MeasureResultReportParamUiModel(
                     drinkingStartTime = drinkingStartTime,
                     drinkingEndTime = getDateTimeNow(),
@@ -56,6 +63,7 @@ class MeasuringViewModel @Inject constructor(
                     totalDrinkGlasses = state.value.totalCount,
                 ).toDomainModel(),
             )
+            _createReportSuccessEvent.value = Event(result.id)
         }
     }
 

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/MeasuringWebViewBridge.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/MeasuringWebViewBridge.kt
@@ -3,9 +3,12 @@ package com.mashup.alcoholfree.presentation.ui.measuring
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
 
-object MeasuringWebViewBridge : SulSulWebViewSendBridge {
-    private const val WEB_FUNCTION_NAME = "addBall"
-    private const val BRIDGE_NAME = "sulsulBridge"
+private const val WEB_FUNCTION_NAME = "addBall"
+private const val BRIDGE_NAME = "sulsulBridge"
+
+class MeasuringWebViewBridge(
+    private val onSuccess: (String) -> Unit,
+) : SulSulWebViewSendBridge {
 
     override val bridgeName: String = BRIDGE_NAME
 
@@ -38,6 +41,6 @@ object MeasuringWebViewBridge : SulSulWebViewSendBridge {
     @JavascriptInterface
     fun onAddBallSuccess(alcoholType: String) {
         // 주량 측정
-        println(alcoholType)
+        onSuccess(alcoholType)
     }
 }

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/MeasuringWebViewBridge.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/MeasuringWebViewBridge.kt
@@ -3,9 +3,6 @@ package com.mashup.alcoholfree.presentation.ui.measuring
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
 
-private const val WEB_FUNCTION_NAME = "addBall"
-private const val BRIDGE_NAME = "sulsulBridge"
-
 class MeasuringWebViewBridge(
     private val onSuccess: (String) -> Unit,
 ) : SulSulWebViewSendBridge {
@@ -42,5 +39,10 @@ class MeasuringWebViewBridge(
     fun onAddBallSuccess(alcoholType: String) {
         // 주량 측정
         onSuccess(alcoholType)
+    }
+
+    companion object {
+        private const val WEB_FUNCTION_NAME = "addBall"
+        private const val BRIDGE_NAME = "sulsulBridge"
     }
 }

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/utils/EventWrapper.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/utils/EventWrapper.kt
@@ -1,0 +1,35 @@
+package com.mashup.alcoholfree.presentation.utils
+
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import java.util.concurrent.atomic.AtomicBoolean
+
+open class Event<out T>(private val content: T) {
+    private var hasBeenHandled = AtomicBoolean(false)
+
+    fun getContentIfNotHandled(): T? {
+        return if (hasBeenHandled.compareAndSet(false, true)) {
+            content
+        } else {
+            null
+        }
+    }
+
+    fun peekContent(): T = content
+}
+
+class EventObserver<T>(private val onEventUnhandledContent: (T) -> Unit) : Observer<Event<T>> {
+    override fun onChanged(value: Event<T>) {
+        value.getContentIfNotHandled()?.let {
+            onEventUnhandledContent(it)
+        }
+    }
+}
+
+fun <T> LiveData<Event<T>>.observeEvent(
+    owner: LifecycleOwner,
+    onEventUnhandledContent: (T) -> Unit,
+) {
+    observe(owner, EventObserver(onEventUnhandledContent))
+}

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/utils/EventWrapper.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/utils/EventWrapper.kt
@@ -5,6 +5,9 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
 import java.util.concurrent.atomic.AtomicBoolean
 
+/**
+ * 한번만 실행해야 하는 이벤트를 처리할 때 사용
+ */
 open class Event<out T>(private val content: T) {
     private var hasBeenHandled = AtomicBoolean(false)
 


### PR DESCRIPTION
close #92 

- 웹과 통신에 성공할 때마다 카운트를 증가시켜 화면에 표출합니당
- 측정 끝내기 버튼 누르면 측정 결과 화면으로 reportId 전달하면서 이동!

![주량 측정](https://github.com/mash-up-kr/SulSul-Android/assets/78132126/7ba0d697-3a02-497e-bd0e-b304c21c2168)

## TODO
- 뱃지는 주량 넘었는지 서버랑 통신 결과로 설정하는거라 현재는 안들어가있습니당