### PR TITLE
#94 [주량 측정]다이얼로그 창 이벤트 발생 구현 

### DIFF
--- a/data/src/main/java/com/mashup/alcoholfree/data/datasource/MeasureDataSource.kt
+++ b/data/src/main/java/com/mashup/alcoholfree/data/datasource/MeasureDataSource.kt
@@ -1,6 +1,8 @@
 package com.mashup.alcoholfree.data.datasource
 
+import com.mashup.alcoholfree.data.dto.remote.request.AlcoholLimitRequest
 import com.mashup.alcoholfree.data.dto.remote.request.MeasureResultReportRequest
+import com.mashup.alcoholfree.data.dto.remote.response.AlcoholLimitResponse
 import com.mashup.alcoholfree.data.dto.remote.response.MeasureResultReportResponse
 import com.mashup.alcoholfree.data.dto.remote.response.MeasureResultResponse
 import com.mashup.alcoholfree.data.service.SulSulService
@@ -19,6 +21,12 @@ class MeasureDataSource @Inject constructor(
     suspend fun createMeasureResultReport(resultReport: MeasureResultReportRequest): MeasureResultReportResponse {
         return sulSulService
             .requestMeasureResultReport(resultReport)
+            .await()
+    }
+
+    suspend fun getAlcoholLimit(consumeAlcohol: AlcoholLimitRequest): AlcoholLimitResponse {
+        return sulSulService
+            .requestAlcoholLimit(consumeAlcohol)
             .await()
     }
 }

--- a/data/src/main/java/com/mashup/alcoholfree/data/dto/remote/request/AlcoholLimitRequest.kt
+++ b/data/src/main/java/com/mashup/alcoholfree/data/dto/remote/request/AlcoholLimitRequest.kt
@@ -1,0 +1,11 @@
+package com.mashup.alcoholfree.data.dto.remote.request
+
+import com.mashup.alcoholfree.domain.model.AlcoholLimitParam
+
+data class AlcoholLimitRequest(
+    val drinks: List<ConsumeDrinkRequest>,
+)
+
+fun AlcoholLimitParam.toRequestModel() = AlcoholLimitRequest(
+    drinks = drinks.map { it.toRequestConsumeDrinkModel() },
+)

--- a/data/src/main/java/com/mashup/alcoholfree/data/dto/remote/request/ConsumeDrinkRequest.kt
+++ b/data/src/main/java/com/mashup/alcoholfree/data/dto/remote/request/ConsumeDrinkRequest.kt
@@ -1,0 +1,13 @@
+package com.mashup.alcoholfree.data.dto.remote.request
+
+import com.mashup.alcoholfree.domain.model.Drink
+
+data class ConsumeDrinkRequest(
+    val drinkType: String,
+    val glass: Int,
+)
+
+fun Drink.toRequestConsumeDrinkModel() = ConsumeDrinkRequest(
+    drinkType = drinkType,
+    glass = glasses,
+)

--- a/data/src/main/java/com/mashup/alcoholfree/data/dto/remote/response/AlcoholLimitResponse.kt
+++ b/data/src/main/java/com/mashup/alcoholfree/data/dto/remote/response/AlcoholLimitResponse.kt
@@ -1,0 +1,18 @@
+package com.mashup.alcoholfree.data.dto.remote.response
+
+import com.google.gson.annotations.SerializedName
+import com.mashup.alcoholfree.domain.model.ConsumeDrinkInfo
+
+data class AlcoholLimitResponse(
+    @SerializedName("isDrunken")
+    val isDrunken: Boolean,
+    @SerializedName("title")
+    val title: DrinkInfoResponse,
+) {
+    fun toDomainModel(): ConsumeDrinkInfo {
+        return ConsumeDrinkInfo(
+            isDrunken = isDrunken,
+            title = title.toDomainModel(),
+        )
+    }
+}

--- a/data/src/main/java/com/mashup/alcoholfree/data/dto/remote/response/DrinkInfoResponse.kt
+++ b/data/src/main/java/com/mashup/alcoholfree/data/dto/remote/response/DrinkInfoResponse.kt
@@ -1,0 +1,18 @@
+package com.mashup.alcoholfree.data.dto.remote.response
+
+import com.google.gson.annotations.SerializedName
+import com.mashup.alcoholfree.domain.model.DrinkInfo
+
+data class DrinkInfoResponse(
+    @SerializedName("imageUrl")
+    val imageUrl: String,
+    @SerializedName("text")
+    val text: String,
+) {
+    fun toDomainModel(): DrinkInfo {
+        return DrinkInfo(
+            imageUrl = imageUrl,
+            text = text,
+        )
+    }
+}

--- a/data/src/main/java/com/mashup/alcoholfree/data/repository/MeasureRepositoryImpl.kt
+++ b/data/src/main/java/com/mashup/alcoholfree/data/repository/MeasureRepositoryImpl.kt
@@ -2,6 +2,8 @@ package com.mashup.alcoholfree.data.repository
 
 import com.mashup.alcoholfree.data.datasource.MeasureDataSource
 import com.mashup.alcoholfree.data.dto.remote.request.toRequestModel
+import com.mashup.alcoholfree.domain.model.AlcoholLimitParam
+import com.mashup.alcoholfree.domain.model.ConsumeDrinkInfo
 import com.mashup.alcoholfree.domain.model.MeasureResult
 import com.mashup.alcoholfree.domain.model.MeasureResultReportId
 import com.mashup.alcoholfree.domain.model.MeasureResultReportParam
@@ -23,5 +25,11 @@ class MeasureRepositoryImpl @Inject constructor(
                 .createMeasureResultReport(resultReport.toRequestModel())
                 .id,
         )
+    }
+
+    override suspend fun getAlcoholLimit(checkAlcohol: AlcoholLimitParam): ConsumeDrinkInfo {
+        return measureDataSource
+            .getAlcoholLimit(checkAlcohol.toRequestModel())
+            .toDomainModel()
     }
 }

--- a/data/src/main/java/com/mashup/alcoholfree/data/service/SulSulService.kt
+++ b/data/src/main/java/com/mashup/alcoholfree/data/service/SulSulService.kt
@@ -1,7 +1,9 @@
 package com.mashup.alcoholfree.data.service
 
+import com.mashup.alcoholfree.data.dto.remote.request.AlcoholLimitRequest
 import com.mashup.alcoholfree.data.dto.remote.request.MeasureResultReportRequest
 import com.mashup.alcoholfree.data.dto.remote.request.RegisterTierRequest
+import com.mashup.alcoholfree.data.dto.remote.response.AlcoholLimitResponse
 import com.mashup.alcoholfree.data.dto.remote.response.MeasureResultReportResponse
 import com.mashup.alcoholfree.data.dto.remote.response.MeasureResultResponse
 import com.mashup.alcoholfree.data.dto.remote.response.MyInfoResponse
@@ -49,4 +51,12 @@ interface SulSulService {
     fun registerDrinkingLimit(
         @Body registerTierRequest: RegisterTierRequest,
     ): Call<RegisterDrinkingLimitResponse>
+
+    /**
+     *  주량 측정 클릭 이벤트, 본인 주량 요청
+     */
+    @POST("/api/v1/drinkingReport/click-event")
+    fun requestAlcoholLimit(
+        @Body consumeAlcohol: AlcoholLimitRequest,
+    ): Call<AlcoholLimitResponse>
 }

--- a/domain/src/main/java/com/mashup/alcoholfree/domain/model/AlcoholLimitParam.kt
+++ b/domain/src/main/java/com/mashup/alcoholfree/domain/model/AlcoholLimitParam.kt
@@ -1,0 +1,5 @@
+package com.mashup.alcoholfree.domain.model
+
+data class AlcoholLimitParam(
+    val drinks: List<Drink>,
+)

--- a/domain/src/main/java/com/mashup/alcoholfree/domain/model/ConsumeDrinkInfo.kt
+++ b/domain/src/main/java/com/mashup/alcoholfree/domain/model/ConsumeDrinkInfo.kt
@@ -1,0 +1,6 @@
+package com.mashup.alcoholfree.domain.model
+
+data class ConsumeDrinkInfo(
+    val isDrunken: Boolean,
+    val title: DrinkInfo,
+)

--- a/domain/src/main/java/com/mashup/alcoholfree/domain/model/DrinkInfo.kt
+++ b/domain/src/main/java/com/mashup/alcoholfree/domain/model/DrinkInfo.kt
@@ -1,0 +1,6 @@
+package com.mashup.alcoholfree.domain.model
+
+data class DrinkInfo(
+    val imageUrl: String,
+    val text: String,
+)

--- a/domain/src/main/java/com/mashup/alcoholfree/domain/repository/MeasureRepository.kt
+++ b/domain/src/main/java/com/mashup/alcoholfree/domain/repository/MeasureRepository.kt
@@ -1,5 +1,7 @@
 package com.mashup.alcoholfree.domain.repository
 
+import com.mashup.alcoholfree.domain.model.AlcoholLimitParam
+import com.mashup.alcoholfree.domain.model.ConsumeDrinkInfo
 import com.mashup.alcoholfree.domain.model.MeasureResult
 import com.mashup.alcoholfree.domain.model.MeasureResultReportId
 import com.mashup.alcoholfree.domain.model.MeasureResultReportParam
@@ -7,4 +9,5 @@ import com.mashup.alcoholfree.domain.model.MeasureResultReportParam
 interface MeasureRepository {
     suspend fun getMeasureResult(reportId: String): MeasureResult
     suspend fun createMeasureResultReport(resultReport: MeasureResultReportParam): MeasureResultReportId
+    suspend fun getAlcoholLimit(consumeAlcohol: AlcoholLimitParam): ConsumeDrinkInfo
 }

--- a/domain/src/main/java/com/mashup/alcoholfree/domain/usecase/GetAlcoholLimitUseCase.kt
+++ b/domain/src/main/java/com/mashup/alcoholfree/domain/usecase/GetAlcoholLimitUseCase.kt
@@ -1,0 +1,16 @@
+package com.mashup.alcoholfree.domain.usecase
+
+import com.mashup.alcoholfree.domain.model.AlcoholLimitParam
+import com.mashup.alcoholfree.domain.model.ConsumeDrinkInfo
+import com.mashup.alcoholfree.domain.repository.MeasureRepository
+import dagger.Reusable
+import javax.inject.Inject
+
+@Reusable
+class GetAlcoholLimitUseCase @Inject constructor(
+    private val measureRepository: MeasureRepository,
+) {
+    suspend operator fun invoke(consumeAlcohol: AlcoholLimitParam): ConsumeDrinkInfo {
+        return measureRepository.getAlcoholLimit(consumeAlcohol)
+    }
+}

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/MeasuringScreen.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/MeasuringScreen.kt
@@ -64,6 +64,11 @@ fun MeasuringScreen(
     onAddBallSuccess: (String) -> Unit = {},
 ) {
     val gradientColorList = setGradientColor(state.currentAlcoholId)
+
+    if (state.isDrunken) {
+        AlcoholExceedDialog()
+    }
+
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -260,6 +265,7 @@ private fun MeasuringScreenPreview() {
                     level = "미쳤다",
                     currentAlcoholId = alcoholId,
                     alcoholTypes = ImmutableList(listOf("소주", "맥주", "위스키", "와인", "고량주")),
+                    isDrunken = false,
                 ),
             )
         }

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/model/AlcoholLimitParamUiModel.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/model/AlcoholLimitParamUiModel.kt
@@ -1,0 +1,16 @@
+package com.mashup.alcoholfree.presentation.ui.measuring.model
+
+import com.mashup.alcoholfree.domain.model.AlcoholLimitParam
+import com.mashup.alcoholfree.presentation.ui.home.model.DrinkUiModel
+import com.mashup.alcoholfree.presentation.ui.home.model.toDomainModel
+
+data class AlcoholLimitParamUiModel(
+    val drinks: List<DrinkUiModel>,
+)
+
+fun AlcoholLimitParamUiModel.toDomainModel() =
+    AlcoholLimitParam(
+        drinks = drinks.map {
+            it.toDomainModel()
+        },
+    )

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/model/ConsumeDrinkInfoUiModel.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/model/ConsumeDrinkInfoUiModel.kt
@@ -1,0 +1,15 @@
+package com.mashup.alcoholfree.presentation.ui.measuring.model
+
+import com.mashup.alcoholfree.domain.model.ConsumeDrinkInfo
+
+data class ConsumeDrinkInfoUiModel(
+    val isDrunken: Boolean,
+    val title: DrinkInfoUiModel,
+)
+
+fun ConsumeDrinkInfo.toUiModel(): ConsumeDrinkInfoUiModel {
+    return ConsumeDrinkInfoUiModel(
+        isDrunken = isDrunken,
+        title = title.toUiModel(),
+    )
+}

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/model/DrinkInfoUiModel.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/model/DrinkInfoUiModel.kt
@@ -1,0 +1,15 @@
+package com.mashup.alcoholfree.presentation.ui.measuring.model
+
+import com.mashup.alcoholfree.domain.model.DrinkInfo
+
+data class DrinkInfoUiModel(
+    val imageUrl: String,
+    val text: String,
+)
+
+fun DrinkInfo.toUiModel(): DrinkInfoUiModel {
+    return DrinkInfoUiModel(
+        imageUrl = imageUrl,
+        text = text,
+    )
+}

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/model/MeasuringState.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/model/MeasuringState.kt
@@ -8,4 +8,5 @@ data class MeasuringState(
     val level: String,
     val currentAlcoholId: Int,
     val alcoholTypes: ImmutableList<String>,
+    val isDrunken: Boolean,
 )


### PR DESCRIPTION
<img src = https://github.com/mash-up-kr/SulSul-Android/assets/59912150/3e3673ee-417b-48db-b7d1-d17759d6be9f  width = 300/>

+ 내 주량 받아오는 api 작성해서 연결까지 완료 했습니다~
+ 이름 짓기가 굉장히 힘들었는데, 결론적으로 기능이 마신 술을 보내고 내 주량이 초과 되었는지, 티어가 얼마인지 아는 것이 목표라고 생각해서 getDrinkLimit으로 네이밍 했습니다. 더 좋은 이름이 있다면 추천해주세용~
+ 티어 까지 받아와서 티어도 잘 바뀝니다~
+ **위 영상은 1잔일때 티어가 공백으로 뜨는데 영상을 찍을때 stateFlow에서 초기값을 ""로 줘서 그랬구여 지금 코드 상으로는 문제 없습니당~**