### PR TITLE
#135 [홈] 카드 메인 텍스트 많이 마신 순으로 정렬

### DIFF
--- a/data/src/main/java/com/mashup/alcoholfree/data/dto/remote/response/CardResponse.kt
+++ b/data/src/main/java/com/mashup/alcoholfree/data/dto/remote/response/CardResponse.kt
@@ -15,10 +15,15 @@ data class CardResponse(
     @SerializedName("drankAt")
     val drankAt: String,
 ) {
-    fun toDomainModel() = PromiseCard(
-        reportId = id,
-        cardType = drinks.first().drinkType,
-        drinks = drinks.map { it.toDomainModel() },
-        drankDate = drankAt,
-    )
+    fun toDomainModel(): PromiseCard {
+        val sortedDrinks = drinks
+            .map { it.toDomainModel() }
+            .sortedByDescending { it.glasses }
+        return PromiseCard(
+            reportId = id,
+            cardType = sortedDrinks.first().drinkType,
+            drinks = sortedDrinks,
+            drankDate = drankAt,
+        )
+    }
 }

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/component/AlcoholPromiseCard.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/component/AlcoholPromiseCard.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -21,7 +20,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -30,13 +28,11 @@ import com.mashup.alcoholfree.presentation.ui.component.SulSulMiddleBadge
 import com.mashup.alcoholfree.presentation.ui.component.model.SulSulBadgeType
 import com.mashup.alcoholfree.presentation.ui.home.model.AlcoholPromiseCardState
 import com.mashup.alcoholfree.presentation.ui.home.model.AlcoholPromiseCardType
-import com.mashup.alcoholfree.presentation.ui.home.model.DrinkUiModel
 import com.mashup.alcoholfree.presentation.ui.theme.AlcoholFreeAndroidTheme
 import com.mashup.alcoholfree.presentation.ui.theme.Grey300
 import com.mashup.alcoholfree.presentation.ui.theme.H2
 import com.mashup.alcoholfree.presentation.ui.theme.ParagraphLg
 import com.mashup.alcoholfree.presentation.ui.theme.White
-import com.mashup.alcoholfree.presentation.utils.ImmutableList
 
 private val cardShape = RoundedCornerShape(16.dp)
 
@@ -82,9 +78,13 @@ fun AlcoholPromiseCard(
             contentScale = ContentScale.Fit,
             contentDescription = null,
         )
-        AlcoholTypeCount(
+        Text(
             modifier = Modifier.padding(horizontal = 32.dp),
-            list = state.drinks.list,
+            text = state.drinks,
+            style = H2,
+            color = White,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
         )
         Text(
             modifier = Modifier.padding(start = 32.dp),
@@ -100,36 +100,6 @@ fun AlcoholPromiseCard(
     }
 }
 
-@Composable
-private fun AlcoholTypeCount(
-    modifier: Modifier = Modifier,
-    list: List<DrinkUiModel>,
-) {
-    Row(
-        modifier = modifier,
-    ) {
-        list.forEachIndexed { index, alcohol ->
-            val text = stringResource(
-                id = R.string.alcohol_record_count,
-                alcohol.alcoholType,
-                alcohol.glasses,
-            )
-
-            Text(
-                text = if (index != list.size - 1) {
-                    "$text, "
-                } else {
-                    text
-                },
-                style = H2,
-                color = White,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        }
-    }
-}
-
 @Preview
 @Composable
 private fun AlcoholPromiseCardPreview() {
@@ -137,13 +107,8 @@ private fun AlcoholPromiseCardPreview() {
         AlcoholPromiseCard(
             state = AlcoholPromiseCardState(
                 id = "",
-                cardType = AlcoholPromiseCardType.SOJU,
-                drinks = ImmutableList(
-                    listOf(
-                        DrinkUiModel("맥주", 1),
-                        DrinkUiModel("와인", 2),
-                    ),
-                ),
+                cardType = AlcoholPromiseCardType.BEER,
+                drinks = "맥주 2잔, 와인 1잔",
                 drankDate = "2023.08.21",
                 subTitleText = "술 좀 치네",
             ),

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/model/AlcoholPromiseCardState.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/model/AlcoholPromiseCardState.kt
@@ -1,11 +1,9 @@
 package com.mashup.alcoholfree.presentation.ui.home.model
 
-import com.mashup.alcoholfree.presentation.utils.ImmutableList
-
 data class AlcoholPromiseCardState(
     val id: String,
     val cardType: AlcoholPromiseCardType,
-    val drinks: ImmutableList<DrinkUiModel>,
+    val drinks: String,
     val drankDate: String,
     val subTitleText: String,
 )

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/model/AlcoholPromiseCardUiModel.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/home/model/AlcoholPromiseCardUiModel.kt
@@ -3,12 +3,11 @@ package com.mashup.alcoholfree.presentation.ui.home.model
 import com.mashup.alcoholfree.domain.model.PromiseCard
 import com.mashup.alcoholfree.presentation.ui.home.model.AlcoholPromiseCardType.Companion.getCardType
 import com.mashup.alcoholfree.presentation.utils.DateFormatter
-import com.mashup.alcoholfree.presentation.utils.ImmutableList
 
 data class AlcoholPromiseCardUiModel(
     val id: String,
     val cardType: AlcoholPromiseCardType,
-    val drinks: List<DrinkUiModel>,
+    val drinks: String,
     val drankDate: String,
     val subTitleText: String,
 )
@@ -17,7 +16,9 @@ fun PromiseCard.toUiModel(): AlcoholPromiseCardUiModel {
     return AlcoholPromiseCardUiModel(
         id = reportId,
         cardType = getCardType(cardType),
-        drinks = drinks.map { it.toUiModel() },
+        drinks = drinks.joinToString(", ") { drink ->
+            "${drink.drinkType} ${drink.glasses}잔"
+        },
         drankDate = DateFormatter.dateFormat(drankDate),
         // TODO("칭호 필요합니당")
         subTitleText = "임시",
@@ -28,7 +29,7 @@ fun AlcoholPromiseCardUiModel.toUiState(): AlcoholPromiseCardState {
     return AlcoholPromiseCardState(
         id = id,
         cardType = cardType,
-        drinks = ImmutableList(drinks),
+        drinks = drinks,
         drankDate = drankDate,
         subTitleText = subTitleText,
     )


### PR DESCRIPTION
- close #135 

정렬하고 나서 보니 왼쪽처럼 말줄임표가 안나타나고 텍스트가 잘리는 것 같길래 같이 수정
(했는데 뭔가.. 줄바꿈이 더 좋을 것 같기도 하고 그러네요)

<img src="https://github.com/mash-up-kr/SulSul-Android/assets/78132126/36c11d52-eeed-4bca-92d9-9f4e0150ae3a" width="300" />
<img src="https://github.com/mash-up-kr/SulSul-Android/assets/78132126/02a2c732-bf77-4ac0-8611-13d4ef9f8c98" width="300" />
