### PR TITLE
#148 [주량 측정] 주종 변경 컴포넌트 깨짐

### DIFF
--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/AlcoholSelection.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/AlcoholSelection.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -106,15 +105,16 @@ private fun AlcoholSelectionRow(
         AlcoholSelectionPager(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = defaultIconButtonSize)
+                .padding(horizontal = 12.dp)
                 .align(Alignment.Center),
             items = items,
             selectedPage = selectedIndex,
         )
         Row(
             modifier = Modifier
-                .fillMaxWidth()
+                .matchParentSize()
                 .background(brush = selectionGradientBrush),
+            verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {
             IconButton(

--- a/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/AlcoholSelection.kt
+++ b/presentation/src/main/java/com/mashup/alcoholfree/presentation/ui/measuring/AlcoholSelection.kt
@@ -162,7 +162,6 @@ private fun AlcoholSelectionPager(
         userScrollEnabled = false,
     ) { page ->
         Text(
-            modifier = Modifier.width(72.dp),
             text = items[page],
             style = H2,
             color = White,


### PR DESCRIPTION
- close #148 

- 글자 크기 최대, 화면 크게 최대 까지는 대응하지 못했지만 그라디언트 높이를 페이저 높이에 맞춰서 그라디언트는 글자가 커져도 안깨지도록 해뒀습니당

<img width="300" src="https://github.com/mash-up-kr/SulSul-Android/assets/78132126/43e2b8a5-4968-4b65-8543-5c30f9355f3a" />
<img width="300" src="https://github.com/mash-up-kr/SulSul-Android/assets/78132126/fc0e6b8d-7e84-4c10-8c8e-109289e58adf" />
